### PR TITLE
Add new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ performed to `http://www.old-legacy-system.com/auth/bob`, with the body:
 }
 ```
 
-If the plugin is configured to use the user id as the path parameter for the credential verification request, the `POST`
-request will be performed to `http://www.old-legacy-system.com/auth/12345678`, instead.
+If the plugin is configured to use the user email as the path parameter for the credential verification request, the `POST`
+request will be performed to `http://www.old-legacy-system.com/auth/bob%40company.com`, instead.
 
 As this is the correct password, the user will be logged in. After the first successful login, the federation link to
 the legacy system is severed and any interactions with the user will be done completely through Keycloak.
@@ -308,6 +308,28 @@ If basic auth is enabled, the username and password will be sent in the authoriz
 Authorization: Basic base64encode(username:password)
 ```
 
+### Use email for credential verification
+
+When doing the request to validate the credentials against the legacy system, this will use email address instead of
+username in the path. The value is URL encoded.  
+Setting `Off`:
+```
+http://www.old-legacy-system.com/auth/bob
+```
+Setting `On`
+```
+http://www.old-legacy-system.com/auth/bob%40company.com
+```
+
+### Replace username with Keycloak ID
+
+Uses the Keycloak ID as username. Depending on the setting `Use email for credential verification` the username is
+either:
+   * If `On`: Set when the user is created
+   * If `Off`: User is created with the username from the legacy system, when the Federation Link is removed
+     the username is replaced with the Keycloak ID
+
+
 ### Legacy role conversion
 
 ![Conversion](readme-images/config_conversion.png)
@@ -320,7 +342,7 @@ automatically map legacy roles to Keycloak roles, by specifying the mapping in t
 This switch can be toggled to decide whether roles which are not defined in the legacy role conversion map should be
 migrated anyway or simply ignored.
 
-### Restrict to client roles
+### Restrict role actions to client
 
 If enabled, and 'Valid for Client ID' is set, only roles defined on that client will be used. If migration
 can create roles, they will be created on the client.  
@@ -336,6 +358,19 @@ automatically map legacy groups to Keycloak groups, by specifying the mapping in
 
 This switch can be toggled to decide whether groups which are not defined in the legacy group conversion map should be
 migrated anyway or simply ignored.
+
+### Get additional user info from other migrations
+
+If having multiple legacy systems that users will be migrated from, and a user can have an account in several, this
+can be enabled to call other migrations, allowing them to get user info from the legacy system they are configured for,
+and update the Keycloak user. The call is done to the user info endpoint using the email address.
+The info that is set in Keycloak is:
+ - Role
+ - Group
+ - Custom attributes
+
+It is recommended to have the migrations configured for a client, `Valid for Client ID`, and have setting
+`Restrict role actions to client` set to `On`.
 
 ## Totp
 

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/ConfigurationProperties.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/ConfigurationProperties.java
@@ -15,13 +15,15 @@ public final class ConfigurationProperties {
     public static final String API_HTTP_BASIC_ENABLED_PROPERTY = "API_HTTP_BASIC_ENABLED";
     public static final String API_HTTP_BASIC_USERNAME_PROPERTY = "API_HTTP_BASIC_USERNAME";
     public static final String API_HTTP_BASIC_PASSWORD_PROPERTY = "API_HTTP_BASIC_PASSWORD";
-    public static final String USE_USER_ID_FOR_CREDENTIAL_VERIFICATION = "USE_USER_ID_FOR_CREDENTIAL_VERIFICATION";
+    public static final String USE_EMAIL_FOR_CREDENTIAL_VERIFICATION_PROPERTY = "USE_EMAIL_FOR_CREDENTIAL_VERIFICATION";
     public static final String ROLE_MAP_PROPERTY = "ROLE_MAP";
     public static final String GROUP_MAP_PROPERTY = "GROUP_MAP";
     public static final String MIGRATE_UNMAPPED_ROLES_PROPERTY = "MIGRATE_UNMAPPED_ROLES";
     public static final String MIGRATE_UNMAPPED_GROUPS_PROPERTY = "MIGRATE_UNMAPPED_GROUPS";
     public static final String VALID_FOR_CLIENT_PROPERTY = "VALID_FOR_CLIENT";
     public static final String RESTRICT_ROLES_TO_CLIENT_PROPERTY = "RESTRICT_ROLES_TO_CLIENT";
+    public static final String USE_ID_AS_USERNAME_PROPERTY = "USE_ID_AS_USERNAME";
+    public static final String GET_USER_INFO_FROM_ALL_USER_MIGRATIONS_PROPERTY = "GET_USER_INFO_FROM_ALL_USER_MIGRATIONS";
 
     private static final List<ProviderConfigProperty> PROPERTIES = List.of(
             new ProviderConfigProperty(URI_PROPERTY,
@@ -31,11 +33,11 @@ public final class ConfigurationProperties {
             new ProviderConfigProperty(VALID_FOR_CLIENT_PROPERTY,
                     "Valid for Client ID",
                     """
-                            The migration can be restricted to only migrate users logging in \
-                            using a specific client. Only roles defined on the client will be used. \
-                            New roles will be created on the client instead of in Realm Roles.
-                            Enter a Client ID, or leave blank if valid for all clients.
-                            """,
+                        The migration can be restricted to only migrate users logging in \
+                        using a specific client. Only roles defined on the client will be used. \
+                        New roles will be created on the client instead of in Realm Roles.
+                        Enter a Client ID, or leave blank if valid for all clients.
+                    """,
                     STRING_TYPE,
                     null),
             new ProviderConfigProperty(API_TOKEN_ENABLED_PROPERTY,
@@ -58,10 +60,20 @@ public final class ConfigurationProperties {
                     "Rest client basic auth password",
                     "HTTP basic auth password for legacy user service",
                     PASSWORD, null),
-            new ProviderConfigProperty(USE_USER_ID_FOR_CREDENTIAL_VERIFICATION,
-                    "Use user id for credential verification",
-                    "Use the id of the user instead of the username as the path " +
-                    "parameter when making a credential verification request",
+            new ProviderConfigProperty(USE_EMAIL_FOR_CREDENTIAL_VERIFICATION_PROPERTY,
+                    "Use email for credential verification",
+                    "Use the user's email instead of the username as the path " +
+                    "parameter when making the credential verification request.",
+                    BOOLEAN_TYPE, false),
+            new ProviderConfigProperty(USE_ID_AS_USERNAME_PROPERTY,
+                    "Replace username with Keycloak ID",
+                    """
+                        Helps prevent conflicts when importing users from several legacy systems.
+                        The behaviour depends on 'Use email for credential verification':
+                        If `On` the user is created with Keycloak ID as username.
+                        If `Off`, the user will be created using the legacy system username, and updated to use \
+                        the Keycloak ID when the Federation Link is removed.
+                    """,
                     BOOLEAN_TYPE, false),
             new ProviderConfigProperty(ROLE_MAP_PROPERTY,
                     "Legacy role conversion",
@@ -86,7 +98,15 @@ public final class ConfigurationProperties {
             new ProviderConfigProperty(MIGRATE_UNMAPPED_GROUPS_PROPERTY,
                     "Migrate unmapped groups",
                     "Whether or not to migrate groups not found in the field above",
-                    BOOLEAN_TYPE, true)
+                    BOOLEAN_TYPE, true),
+            new ProviderConfigProperty(GET_USER_INFO_FROM_ALL_USER_MIGRATIONS_PROPERTY,
+                    "Get additional user info from other migrations",
+                    """
+                        This will allow other migrations, of this type, to set custom attributes, \
+                        roles and groups that exist in the legacy system that it's configured for.
+                        This is only done when the user is created.
+                    """,
+                    BOOLEAN_TYPE, false)
     );
 
     private ConfigurationProperties() {

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyProvider.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyProvider.java
@@ -18,6 +18,7 @@ import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.user.UserLookupProvider;
 import org.keycloak.storage.user.UserRegistrationProvider;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -31,7 +32,7 @@ import java.util.stream.Stream;
         // No easy way to reduce the dependencies of this class:
         "java:S1200"
 )
-public class LegacyProvider implements UserStorageProvider,
+public class LegacyProvider implements LegacyUserStorageProvider,
         UserLookupProvider,
         CredentialInputUpdater,
         CredentialInputValidator,
@@ -74,9 +75,10 @@ public class LegacyProvider implements UserStorageProvider,
     }
 
     private String getUserIdentifier(UserModel userModel) {
-        var userIdConfig = model.getConfig().getFirst(ConfigurationProperties.USE_USER_ID_FOR_CREDENTIAL_VERIFICATION);
-        var useUserId = Boolean.parseBoolean(userIdConfig);
-        return useUserId ? userModel.getId() : userModel.getUsername();
+        boolean useEmail = Boolean.parseBoolean(
+            model.getConfig().getFirst(ConfigurationProperties.USE_EMAIL_FOR_CREDENTIAL_VERIFICATION_PROPERTY)
+        );
+        return useEmail ? userModel.getEmail() : userModel.getUsername();
     }
 
     private boolean passwordDoesNotBreakPolicy(RealmModel realmModel, UserModel userModel, String password) {
@@ -120,6 +122,7 @@ public class LegacyProvider implements UserStorageProvider,
     @Override
     public boolean updateCredential(RealmModel realm, UserModel user, CredentialInput input) {
         severFederationLink(user);
+        setIdAsUsername(user);
         return false;
     }
 
@@ -128,6 +131,16 @@ public class LegacyProvider implements UserStorageProvider,
         String link = user.getFederationLink();
         if (link != null && !link.isBlank()) {
             user.setFederationLink(null);
+        }
+    }
+
+    private void setIdAsUsername(UserModel user) {
+        boolean idAsUsername = Boolean.parseBoolean(
+            model.getConfig().getFirst(ConfigurationProperties.USE_ID_AS_USERNAME_PROPERTY)
+        );
+
+        if (idAsUsername && !user.getUsername().equals(user.getId())) {
+            user.setUsername(user.getId());
         }
     }
 
@@ -168,11 +181,26 @@ public class LegacyProvider implements UserStorageProvider,
                     }
                     return !duplicate;
                 })
-                .map(u -> userModelFactory.create(u, realm))
+                .map(u -> {
+                    u.attributes().put("Migration handler", List.of(model.getName()));
+                    UserModel newUser = userModelFactory.create(u, realm);
+                    getUserInfoFromOthers(newUser);
+                    return newUser;
+                })
                 .orElseGet(() -> {
                     LOG.warnf("User not found in external repository: %s", username);
                     return null;
                 });
+    }
+
+    @Override
+    public Optional<LegacyUser> getLegacyUserInfo(String email) {
+        return legacyUserService.findByEmail(email);
+    }
+
+    @Override
+    public void updateUserInfo(UserModel user, LegacyUser legacyUser, RealmModel realm) {
+        userModelFactory.update(user, legacyUser, realm);
     }
 
     @Override
@@ -189,5 +217,44 @@ public class LegacyProvider implements UserStorageProvider,
     @Override
     public boolean removeUser(RealmModel realmModel, UserModel userModel) {
         return true;
+    }
+
+    public void getUserInfoFromOthers(UserModel user) {
+        boolean getFromOthers = Boolean.parseBoolean(
+            model.getConfig().getFirst(ConfigurationProperties.GET_USER_INFO_FROM_ALL_USER_MIGRATIONS_PROPERTY)
+        );
+
+        if (!getFromOthers) {
+            return;
+        }
+
+        RealmModel realm = session.getContext().getRealm();
+
+        List<ComponentModel> providerModels = realm.getStorageProviders(UserStorageProvider.class).toList();
+        for (ComponentModel providerModel : providerModels) {
+            // Check that the provider is of our type, and that it's not this model
+            if (providerModel.getProviderId().equals(ConfigurationProperties.PROVIDER_NAME) && !model.getId().equals(providerModel.getId())) {
+                LOG.infof("Found provider named \"%s\" with ID: %s", providerModel.getName(), providerModel.getId());
+                // Using getProvider with providerModel is deprecated, but the replacement, getComponentProvider, always return null
+                LegacyUserStorageProvider legacyProvider = session.getProvider(LegacyUserStorageProvider.class, providerModel);
+
+                if (legacyProvider == null) {
+                    LOG.debug("Provider not found in session, trying to create");
+                    legacyProvider = new LegacyProviderFactory().create(session, providerModel);
+                }
+
+                if (legacyProvider != null) {
+                    LOG.debug("Have provider, getting user info");
+                    Optional<LegacyUser> legacyUser = legacyProvider.getLegacyUserInfo(user.getEmail());
+                    if (legacyUser.isPresent()) {
+                        legacyProvider.updateUserInfo(user, legacyUser.get(), realm);
+                    } else {
+                        LOG.infof("User with email \"%s\" was not found", user.getEmail());
+                    }
+                } else {
+                    LOG.info("Failed getting provider");
+                }
+            }
+        }
     }
 }

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyProviderFactory.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyProviderFactory.java
@@ -7,13 +7,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.LaxRedirectStrategy;
 import org.keycloak.component.ComponentModel;
+import org.keycloak.component.ComponentValidationException;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.storage.UserStorageProviderFactory;
 
 import java.util.List;
 
 import static com.danielfrak.code.keycloak.providers.rest.ConfigurationProperties.PROVIDER_NAME;
+import static com.danielfrak.code.keycloak.providers.rest.ConfigurationProperties.VALID_FOR_CLIENT_PROPERTY;
 
 public class LegacyProviderFactory implements UserStorageProviderFactory<LegacyProvider> {
 
@@ -33,5 +36,13 @@ public class LegacyProviderFactory implements UserStorageProviderFactory<LegacyP
     @Override
     public String getId() {
         return PROVIDER_NAME;
+    }
+
+    @Override
+    public void validateConfiguration(KeycloakSession session, RealmModel realm, ComponentModel config) throws ComponentValidationException {
+        String selectedClient = config.get(VALID_FOR_CLIENT_PROPERTY, "");
+        if (!selectedClient.isEmpty() && realm.getClientByClientId(selectedClient) == null) {
+            throw new ComponentValidationException(String.format("Client \"%s\" does not exist", selectedClient));
+        }
     }
 }

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyUserStorageProvider.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyUserStorageProvider.java
@@ -1,0 +1,13 @@
+package com.danielfrak.code.keycloak.providers.rest;
+
+import com.danielfrak.code.keycloak.providers.rest.remote.LegacyUser;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.storage.UserStorageProvider;
+
+import java.util.Optional;
+
+public interface LegacyUserStorageProvider extends UserStorageProvider {
+    Optional<LegacyUser> getLegacyUserInfo(String email);
+    void updateUserInfo(UserModel user, LegacyUser legacyUser, RealmModel realm);
+}

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/UserModelFactory.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/UserModelFactory.java
@@ -51,10 +51,9 @@ public class UserModelFactory {
     }
 
     public UserModel create(LegacyUser legacyUser, RealmModel realm) {
-        LOG.infof("Creating user model for: %s", legacyUser.username());
+        LOG.infof("Creating user model for: %s", legacyUser.email());
 
         UserModel userModel = addUser(legacyUser, realm);
-        validateUsernamesEqual(legacyUser, userModel);
         migrateBasicAttributes(legacyUser, userModel);
         migrateAdditionalAttributes(legacyUser, userModel);
         migrateRoles(legacyUser, realm, userModel);
@@ -65,42 +64,32 @@ public class UserModelFactory {
         return userModel;
     }
 
+    public void update(UserModel user, LegacyUser legacyUser, RealmModel realm) {
+        LOG.infof("Updating user model for: %s", user.getEmail());
+
+        migrateAdditionalAttributes(legacyUser, user);
+        migrateRoles(legacyUser, realm, user);
+        migrateGroups(legacyUser, realm, user);
+    }
+
     private UserModel addUser(LegacyUser legacyUser, RealmModel realm) {
-        UserModel userModel;
-        if (isEmpty(legacyUser.id())) {
-            userModel = addUserWithoutLegacyId(legacyUser, realm);
-        } else {
-            userModel = addUserWithLegacyId(legacyUser, realm);
+        boolean useEmail = Boolean.parseBoolean(model.getConfig().getFirst(USE_EMAIL_FOR_CREDENTIAL_VERIFICATION_PROPERTY));
+        boolean replaceUsername = Boolean.parseBoolean(model.getConfig().getFirst(USE_ID_AS_USERNAME_PROPERTY));
+
+        String userId = UUID.randomUUID().toString();
+        String userName = legacyUser.username();
+
+        if (useEmail && replaceUsername) {
+            userName = userId;
         }
-        return userModel;
-    }
 
-    private UserModel addUserWithoutLegacyId(LegacyUser legacyUser, RealmModel realm) {
-        UserModel userModel;
-        userModel = session.users().addUser(realm, legacyUser.username());
-        return userModel;
-    }
-
-    private UserModel addUserWithLegacyId(LegacyUser legacyUser, RealmModel realm) {
-        UserModel userModel;
-        boolean addDefaultRoles = true;
-        boolean dontAddDefaultRequiredActions = false;
-        userModel = session.users().addUser(
-                realm,
-                legacyUser.id(),
-                legacyUser.username(),
-                addDefaultRoles,
-                dontAddDefaultRequiredActions
+        return session.users().addUser(
+            realm,
+            userId,
+            userName,
+            true,
+            false
         );
-        return userModel;
-    }
-
-    private void validateUsernamesEqual(LegacyUser legacyUser, UserModel userModel) {
-        if (!userModel.getUsername().equals(legacyUser.username())) {
-            throw new IllegalStateException(String.format("Local and remote users differ: [%s != %s]",
-                    userModel.getUsername(),
-                    legacyUser.username()));
-        }
     }
 
     private void migrateBasicAttributes(LegacyUser legacyUser, UserModel userModel) {

--- a/src/test/java/com/danielfrak/code/keycloak/providers/rest/LegacyProviderTest.java
+++ b/src/test/java/com/danielfrak/code/keycloak/providers/rest/LegacyProviderTest.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.danielfrak.code.keycloak.providers.rest.ConfigurationProperties.USE_USER_ID_FOR_CREDENTIAL_VERIFICATION;
+import static com.danielfrak.code.keycloak.providers.rest.ConfigurationProperties.USE_EMAIL_FOR_CREDENTIAL_VERIFICATION_PROPERTY;
 import static com.danielfrak.code.keycloak.providers.rest.remote.TestLegacyUser.aMinimalLegacyUser;
 import static java.util.Collections.emptySet;
 import static org.junit.jupiter.api.Assertions.*;
@@ -148,7 +148,7 @@ class LegacyProviderTest {
                 .thenReturn(PasswordCredentialModel.TYPE);
 
         MultivaluedHashMap<String, String> config = new MultivaluedHashMap<>();
-        config.put(USE_USER_ID_FOR_CREDENTIAL_VERIFICATION, List.of("false"));
+        config.put(USE_EMAIL_FOR_CREDENTIAL_VERIFICATION_PROPERTY, List.of("false"));
         when(model.getConfig()).thenReturn(config);
 
         final String username = "user";
@@ -174,7 +174,7 @@ class LegacyProviderTest {
                 .thenReturn(PasswordCredentialModel.TYPE);
 
         MultivaluedHashMap<String, String> config = new MultivaluedHashMap<>();
-        config.put(USE_USER_ID_FOR_CREDENTIAL_VERIFICATION, List.of("false"));
+        config.put(USE_EMAIL_FOR_CREDENTIAL_VERIFICATION_PROPERTY, List.of("false"));
         when(model.getConfig()).thenReturn(config);
 
         final String username = "user";
@@ -204,7 +204,7 @@ class LegacyProviderTest {
                 .thenReturn(PasswordCredentialModel.TYPE);
 
         MultivaluedHashMap<String, String> config = new MultivaluedHashMap<>();
-        config.put(USE_USER_ID_FOR_CREDENTIAL_VERIFICATION, List.of("true"));
+        config.put(USE_EMAIL_FOR_CREDENTIAL_VERIFICATION_PROPERTY, List.of("true"));
         when(model.getConfig()).thenReturn(config);
 
         final String userId = "1234567890";
@@ -235,7 +235,7 @@ class LegacyProviderTest {
                 .thenReturn(PasswordCredentialModel.TYPE);
 
         MultivaluedHashMap<String, String> config = new MultivaluedHashMap<>();
-        config.put(USE_USER_ID_FOR_CREDENTIAL_VERIFICATION, List.of("true"));
+        config.put(USE_EMAIL_FOR_CREDENTIAL_VERIFICATION_PROPERTY, List.of("true"));
         when(model.getConfig()).thenReturn(config);
 
         final String userId = "1234567890";
@@ -264,7 +264,7 @@ class LegacyProviderTest {
                 .thenReturn(PasswordCredentialModel.TYPE);
 
         MultivaluedHashMap<String, String> config = new MultivaluedHashMap<>();
-        config.put(USE_USER_ID_FOR_CREDENTIAL_VERIFICATION, List.of("true"));
+        config.put(USE_EMAIL_FOR_CREDENTIAL_VERIFICATION_PROPERTY, List.of("true"));
         when(model.getConfig()).thenReturn(config);
 
         final String userId = "1234567890";


### PR DESCRIPTION
- Add option to use other migrations to update user data. Gets role, groups and custom attributes. Uses the GET endpoint with the users email address as path parameter
- Add option to use the Keycloak ID as username. Helps prevent username conflict
- Change option `Use user id for credential verification` to `Use email for credential verification`
- Validate that the client ID entered in `Valid for Client ID` exists